### PR TITLE
Include the built code in the npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,4 @@
 demo
-dist
 src
 test
 .gitignore


### PR DESCRIPTION
Removes dist from .npmignore so the dist dir can be part of the npm package so that npm can be used to get the bundled code rather than bower etc.
