### PR TITLE
Allow onChange prop to take the component's internal InputMask as an argument

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -75,7 +75,7 @@ var MaskedInput = React.createClass({
       }
     }
     if (this.props.onChange) {
-      this.props.onChange(e)
+      this.props.onChange(e, this.mask)
     }
   },
 
@@ -87,7 +87,7 @@ var MaskedInput = React.createClass({
       if (this.mask.undo()) {
         e.target.value = this._getDisplayValue()
         this._updateInputSelection()
-        this.props.onChange(e)
+        this.props.onChange(e, this.mask)
       }
       return
     }
@@ -96,7 +96,7 @@ var MaskedInput = React.createClass({
       if (this.mask.redo()) {
         e.target.value = this._getDisplayValue()
         this._updateInputSelection()
-        this.props.onChange(e)
+        this.props.onChange(e, this.mask)
       }
       return
     }
@@ -110,7 +110,7 @@ var MaskedInput = React.createClass({
         if (value) {
           this._updateInputSelection()
         }
-        this.props.onChange(e)
+        this.props.onChange(e, this.mask)
       }
     }
   },
@@ -140,7 +140,7 @@ var MaskedInput = React.createClass({
       e.target.value = this.mask.getValue()
       // Timeout needed for IE
       setTimeout(this._updateInputSelection, 0)
-      this.props.onChange(e)
+      this.props.onChange(e, this.mask)
     }
   },
 


### PR DESCRIPTION
It might be helpful to be able to access the component's internal InputMask property as an argument to the onChange handler passed down through props. 

For example, one might desire to call mask.getRawValue() from within the handler as the formatting provided by the component might only be needed for display purposes rather than for storage.
