### PR TITLE
fixed so masked input works with chrome auto-fill and on paste

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -72,6 +72,7 @@ var App = React.createClass({
       leading: '',
       custom: '',
       changing: '',
+      phone: '',
       pattern: '1111 1111'
     }
   },
@@ -111,6 +112,10 @@ var App = React.createClass({
       <div className="form-field">
         <label htmlFor="plate">License Plate:</label>
         <MaskedInput mask="AAA 1111" name="plate" id="plate" onChange={this._onChange} placeholder="ABC 1234"/>
+      </div>
+      <div className="form-field">
+        <label htmlFor="phone">Phone Number:</label>
+        <MaskedInput mask="(111) 111-1111" name="phone" id="phone" onChange={this._onChange} placeholder="(999) 999-9999"/>
       </div>
       <p>Mask placeholder characters can be escaped with a leading <code>\</code> to use them as static contents:</p>
       <div className="form-field">

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -71,6 +71,7 @@ var MaskedInput = React.createClass({
         this.mask.selection.end = this.mask.selection.start + sizeDiff
         this.mask.backspace()
       }
+      this.mask.setValue(e.target.value);
       var value = this._getDisplayValue()
       e.target.value = value
       if (value) {
@@ -145,6 +146,14 @@ var MaskedInput = React.createClass({
       // Timeout needed for IE
       setTimeout(this._updateInputSelection, 0)
       this.props.onChange(e)
+    }
+    else {
+      this.mask.setValue(e.clipboardData.getData('Text'));
+      var value = this._getDisplayValue()
+      e.target.value = value
+      if (value) {
+        this._updateInputSelection()
+      }
     }
   },
 


### PR DESCRIPTION
Fixes issue #21 

Edit:
Rebased onto latest master
Only kept relevant change. Change to dist was dropped to help avoid
merge conflicts
Add phone number example to demo page

Test code (add to demo/index.html):

```
      <form method="post">
        First name: <input type="text" name="fname" />
        Last Name: <input type="text" name="lname" />
      <div className="form-field">
        <label htmlFor="phone">Phone Number:</label>
        <MaskedInput mask="(111) 111-1111" name="phone" id="phone" onChange={this._onChange} placeholder="(999) 999-9999"/>
      </div>
```
