### PR TITLE
Updating React and ReactDOM dependencies to v15

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,13 +31,13 @@
     "inputmask-core": "^2.1.1"
   },
   "peerDependencies": {
-    "react": "0.14.x"
+    "react": "0.14.x || 15.x.x"
   },
   "devDependencies": {
     "eslint-config-jonnybuchanan": "2.0.3",
     "nwb": "0.8.x",
-    "react": "0.14.x",
-    "react-dom": "0.14.x"
+    "react": "15.x.x",
+    "react-dom": "15.x.x"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I used 15.x.x to try to future-proof the React dependencies; should be good for a little while. (15.0.1 was released while I was doing this, which fixed this cursor issue: https://github.com/facebook/react/issues/6445)

No warnings in the console. I tried `npm test`, but there aren't any tests to run.
