### PR TITLE
Added fixes from the PR board.

### DIFF
--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -23,7 +23,8 @@ const App = React.createClass({
       leading: '',
       custom: '',
       changing: '',
-      pattern: '1111 1111'
+      pattern: '1111 1111',
+      cardPattern: '1111 1111 1111 1111'
     }
   },
 
@@ -35,6 +36,14 @@ const App = React.createClass({
 
   _changePattern(e) {
     this.setState({pattern: e.target.value})
+  },
+
+  _onCardChange(e) {
+    if(/^3[47]/.test(e.target.value)) {
+      this.setState({cardPattern: "1111 111111 11111"})
+    } else {
+      this.setState({cardPattern: '1111 1111 1111 1111'})
+    }
   },
 
   render() {
@@ -85,6 +94,11 @@ const App = React.createClass({
         <select onChange={this._changePattern}>
           {PATTERNS.map(pattern => <option value={pattern} key={pattern}>{pattern}</option>)}
         </select>
+      </div>
+      <p>Dynamically changing the pattern as the user types:</p>
+      <div className="form-field">
+        <label htmlFor="changing">Credit Card:</label>
+        <MaskedInput mask={this.state.cardPattern} name="creditCard" id="creditCard" onChange={this._onCardChange}/>
       </div>
       <p>Custom format character (W=[a-zA-Z0-9_], transformed to uppercase) and placeholder character (en space):</p>
       <div className="form-field">

--- a/src/index.js
+++ b/src/index.js
@@ -49,6 +49,25 @@ var MaskedInput = React.createClass({
     }
   },
 
+  componentWillUpdate(nextProps, nextState) {
+    if (nextProps.mask !== this.props.mask) {
+      this._updatePattern(nextProps)
+    }
+  },
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.mask !== this.props.mask && this.mask.selection.start) {
+      this._updateInputSelection()
+    }
+  },
+
+  _updatePattern: function(props) {
+    this.mask.setPattern(props.mask, {
+      value: this.mask.getRawValue(),
+      selection: getSelection(this.input)
+    });
+  },
+
   _updateMaskSelection() {
     this.mask.selection = getSelection(this.input)
   },

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -46,5 +46,46 @@ describe('MaskedInput', () => {
 
     cleanup(el)
   })
+
+  it('should handle updating mask masking', () => {
+    const el = setup()
+    let ref = null
+    let defaultMask = '1111 1111 1111 1111'
+    let amexMask = '1111 111111 11111'
+    let mask = defaultMask
+
+    function render() {
+      ReactDOM.render(
+        <MaskedInput
+          ref={(r) => {
+            if (r) ref = r
+          }}
+          mask={mask}
+        />,
+        el
+      )
+    }
+
+    render();
+    let input = ReactDOM.findDOMNode(ref)
+
+    // initial state
+    expect(input.value).toBe('')
+    expect(input.placeholder).toBe('____ ____ ____ ____')
+    expect(input.size).toBe(19)
+    expect(input.selectionStart).toBe(0)
+
+    mask = amexMask
+    render();
+    input = ReactDOM.findDOMNode(ref)
+
+    // initial state
+    expect(input.value).toBe('')
+    expect(input.placeholder).toBe('____ ______ _____')
+    expect(input.size).toBe(17)
+    expect(input.selectionStart).toBe(0)
+
+    cleanup(el)
+  })
 })
 


### PR DESCRIPTION
Add support for updating the `mask`. Fixes #8.

Previously the cursor would go to the end of the input if you changed the mask or re-created the MaskedInput field.  So, if you have a user typing `34` and then switching the mask to `1111 111111 11111` the cursor would be positioned to the end: `34__ ______ _____^`.

This PR takes suggestions from PR #9.
