### PR TITLE
update new patterns before new values to prevent leftover placeholder characters

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -41,11 +41,12 @@ var MaskedInput = React.createClass({
   },
 
   componentWillReceiveProps(nextProps) {
-    if (this.props.value !== nextProps.value) {
-      this.mask.setValue(nextProps.value)
-    }
+    // update the pattern first to avoid left over placeholders
     if (this.props.mask !== nextProps.mask) {
       this.mask.setPattern(nextProps.mask, {value: this.mask.getRawValue()})
+    }
+    if (this.props.value !== nextProps.value) {
+      this.mask.setValue(nextProps.value)
     }
   },
 

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -89,5 +89,48 @@ describe('MaskedInput', () => {
 
     cleanup(el)
   })
+
+  it('should remove leftover placeholder characters when switching to smaller mask', () => {
+    const el = setup()
+    let ref = null
+    let defaultMask = '1111 1111 1111 1111'
+    let amexMask = '1111 111111 11111'
+    let mask = defaultMask
+    let value = null
+
+    function render(props) {
+      ReactDOM.render(
+        <MaskedInput
+          ref={(r) => {
+            if (r) ref = r
+          }}
+          mask={mask}
+          value={value}
+        />,
+        el
+      )
+    }
+
+    render()
+    let input = ReactDOM.findDOMNode(ref)
+
+    // initial state
+    expect(input.value).toBe('')
+    expect(input.placeholder).toBe('____ ____ ____ ____')
+    expect(input.size).toBe(19)
+    expect(input.selectionStart).toBe(0)
+
+    mask = amexMask
+    value = '1234 123456 12345'
+    render()
+    input = ReactDOM.findDOMNode(ref)
+    console.log(input)
+
+    // initial state
+    expect(input.value).toBe('1234 123456 12345')
+    expect(input.size).toBe(17)
+
+    cleanup(el)
+  })
 })
 


### PR DESCRIPTION
When providing both a new value and new pattern at the same time leftover placeholder characters remain.

This is caused by updating the value before updating the pattern.

This pull request switches the order and adds a test case.
