### PR TITLE
Can't enter more than one character in Edge browser

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -235,7 +235,7 @@ var MaskedInput = React.createClass({
     return value === this.mask.emptyValue ? '' : value
   },
 
-  _keyPressEventProp() {
+  _keyPressPropName() {
     return navigator.userAgent.match(/Android/i)
       ? 'onBeforeInput'
       : 'onKeyPress'
@@ -246,7 +246,7 @@ var MaskedInput = React.createClass({
       onChange: this._onChange,
       onKeyDown: this._onKeyDown,
       onPaste: this._onPaste,
-      [this._keyPressEventProp()]: this._onKeyPress
+      [this._keyPressPropName()]: this._onKeyPress
     }
   },
 

--- a/src/index.js
+++ b/src/index.js
@@ -236,7 +236,7 @@ var MaskedInput = React.createClass({
   },
 
   _userAgentIsEdge() {
-    return navigator.userAgent.match(/(Edge)/i);
+    return navigator.userAgent.match(/(Edge)/i)
   },
 
   _keyPressEventProp() {
@@ -269,7 +269,7 @@ var MaskedInput = React.createClass({
       onPaste: this._onPaste
     }
 
-    eventHandlers[this._keyPressEventProp()] = this._onKeyPress;
+    eventHandlers[this._keyPressEventProp()] = this._onKeyPress
 
     var props = { ...this.props, ...eventHandlers, ref, maxLength, value, size, placeholder }
 

--- a/src/index.js
+++ b/src/index.js
@@ -235,12 +235,21 @@ var MaskedInput = React.createClass({
     return value === this.mask.emptyValue ? '' : value
   },
 
-  _userAgentIsEdge() {
-    return navigator.userAgent.match(/(Edge)/i)
+  _getEventHandlers() {
+    return {
+      onChange: this._onChange,
+      onKeyDown: this._onKeyDown,
+      onPaste: this._onPaste,
+      [this._keyPressEventProp()]: this._onKeyPress
+    }
   },
 
   _keyPressEventProp() {
-    return (this._userAgentIsEdge)
+    var { userAgent } = navigator
+    var isEdge = userAgent.match(/Edge/i)
+    var isNotAndroid = !userAgent.match(/[Aa]ndroid/i)
+
+    return (isEdge || isNotAndroid)
       ? 'onKeyPress'
       : 'onBeforeInput'
   },
@@ -257,19 +266,13 @@ var MaskedInput = React.createClass({
     var ref = (r => this.input = r)
     var maxLength = this.mask.pattern.length
     var value = this._getDisplayValue()
+    var eventHandlers = this._getEventHandlers()
 
     var {
       size = maxLength,
       placeholder = this.mask.emptyValue
     } = this.props
 
-    var eventHandlers = {
-      onChange: this._onChange,
-      onKeyDown: this._onKeyDown,
-      onPaste: this._onPaste
-    }
-
-    eventHandlers[this._keyPressEventProp()] = this._onKeyPress
 
     var props = { ...this.props, ...eventHandlers, ref, maxLength, value, size, placeholder }
 

--- a/src/index.js
+++ b/src/index.js
@@ -235,6 +235,16 @@ var MaskedInput = React.createClass({
     return value === this.mask.emptyValue ? '' : value
   },
 
+  _userAgentIsEdge() {
+    return navigator.userAgent.match(/(Edge)/i);
+  },
+
+  _keyPressEventProp() {
+    return (this._userAgentIsEdge)
+      ? 'onKeyPress'
+      : 'onBeforeInput'
+  },
+
   focus() {
     this.input.focus()
   },
@@ -244,19 +254,26 @@ var MaskedInput = React.createClass({
   },
 
   render() {
-    var {mask, formatCharacters, size, placeholder, placeholderChar, ...props} = this.props
-    var patternLength = this.mask.pattern.length
-    return <input {...props}
-      ref={r => this.input = r }
-      maxLength={patternLength}
-      onChange={this._onChange}
-      onKeyDown={this._onKeyDown}
-      onBeforeInput={this._onKeyPress}
-      onPaste={this._onPaste}
-      placeholder={placeholder || this.mask.emptyValue}
-      size={size || patternLength}
-      value={this._getDisplayValue()}
-    />
+    var ref = (r => this.input = r)
+    var maxLength = this.mask.pattern.length
+    var value = this._getDisplayValue()
+
+    var {
+      size = maxLength,
+      placeholder = this.mask.emptyValue
+    } = this.props
+
+    var eventHandlers = {
+      onChange: this._onChange,
+      onKeyDown: this._onKeyDown,
+      onPaste: this._onPaste
+    }
+
+    eventHandlers[this._keyPressEventProp()] = this._onKeyPress;
+
+    var props = { ...this.props, ...eventHandlers, ref, maxLength, value, size, placeholder }
+
+    return <input {...props} />
   }
 })
 

--- a/src/index.js
+++ b/src/index.js
@@ -247,9 +247,9 @@ var MaskedInput = React.createClass({
   _keyPressEventProp() {
     var { userAgent } = navigator
     var isEdge = userAgent.match(/Edge/i)
-    var isNotAndroid = !userAgent.match(/[Aa]ndroid/i)
+    var isAndroid = userAgent.match(/Android/i)
 
-    return (isEdge || isNotAndroid)
+    return isEdge || isAndroid
       ? 'onKeyPress'
       : 'onBeforeInput'
   },
@@ -263,7 +263,7 @@ var MaskedInput = React.createClass({
   },
 
   render() {
-    var ref = (r => this.input = r)
+    var ref = r => this.input = r
     var maxLength = this.mask.pattern.length
     var value = this._getDisplayValue()
     var eventHandlers = this._getEventHandlers()

--- a/src/index.js
+++ b/src/index.js
@@ -235,6 +235,12 @@ var MaskedInput = React.createClass({
     return value === this.mask.emptyValue ? '' : value
   },
 
+  _keyPressEventProp() {
+    return navigator.userAgent.match(/Android/i)
+      ? 'onBeforeInput'
+      : 'onKeyPress'
+  },
+
   _getEventHandlers() {
     return {
       onChange: this._onChange,
@@ -242,16 +248,6 @@ var MaskedInput = React.createClass({
       onPaste: this._onPaste,
       [this._keyPressEventProp()]: this._onKeyPress
     }
-  },
-
-  _keyPressEventProp() {
-    var { userAgent } = navigator
-    var isEdge = userAgent.match(/Edge/i)
-    var isAndroid = userAgent.match(/Android/i)
-
-    return isEdge || isAndroid
-      ? 'onKeyPress'
-      : 'onBeforeInput'
   },
 
   focus() {
@@ -267,13 +263,7 @@ var MaskedInput = React.createClass({
     var maxLength = this.mask.pattern.length
     var value = this._getDisplayValue()
     var eventHandlers = this._getEventHandlers()
-
-    var {
-      size = maxLength,
-      placeholder = this.mask.emptyValue
-    } = this.props
-
-
+    var { size = maxLength, placeholder = this.mask.emptyValue } = this.props
     var props = { ...this.props, ...eventHandlers, ref, maxLength, value, size, placeholder }
 
     return <input {...props} />


### PR DESCRIPTION
### This is a fix for this issue: https://github.com/insin/react-maskedinput/issues/75

In the end, I had to go with user agent sniffing even though it's a really ugly solution ~and will cause a breakage when Microsoft finally get their **** together~. Anything else was causing unexpected behaviour in other browsers. But it will solve the problem for 99% of users for now.

I did attempt to use feature detection, but it turns out detecting built-in browser events is a really complicated process and I really didn't want to introduce Modernizr just for this.

I also wasn't able to write unit tests for this because I couldn't find a way to make React DOM spoof the user agent and I couldn't find any documentation on how to manually configure PhantomJS on the fly in this test suite configuration.

**Tested in**:
- Mac OS X (El Capitan)
  - Chrome
  - Firefox
  - Safari
- Windows 10
  - Edge
  - Chrome
- Android (5.1.1)
  - Android browser
  - Chrome
- iOS (10.0.2)
  - Safari
  - Chrome
