### PR TITLE
Silence React 15.4 invalid property warnings

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -264,9 +264,10 @@ var MaskedInput = React.createClass({
     var value = this._getDisplayValue()
     var eventHandlers = this._getEventHandlers()
     var { size = maxLength, placeholder = this.mask.emptyValue } = this.props
-    var props = { ...this.props, ...eventHandlers, ref, maxLength, value, size, placeholder }
 
-    return <input {...props} />
+    var {placeholderChar, formatCharacters, ...cleanedProps} = this.props
+    var inputProps = { ...cleanedProps, ...eventHandlers, ref, maxLength, value, size, placeholder }
+    return <input {...inputProps} />
   }
 })
 

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -28,6 +28,7 @@ describe('MaskedInput', () => {
     expect(console.error.calls[0].arguments[0]).toMatch(
       new RegExp('required', 'i')
     )
+    console.error.restore()
   })
 
   it('should handle a masking workflow', () => {

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -209,6 +209,27 @@ describe('MaskedInput', () => {
     cleanup(el)
   })
 
+  it('cleans props from input', () => {
+    const el = setup()
+    let ref = null
+    let defaultMask = '1111 1111 1111 1111'
+    function render(props) {
+      ReactDOM.render(
+        <MaskedInput ref={(r) => ref = r} {...props} />,
+        el
+      )
+    }
+    expect.spyOn(console, 'error')
+    render({mask: defaultMask, value: '',
+            placeholderChar: 'X', formatCharacters: {A: null}})
+    expect(console.error).toNotHaveBeenCalled()
+    console.error.restore()
+    let input = ReactDOM.findDOMNode(ref)
+    expect(input.getAttribute('placeholderChar')).toNotExist()
+    expect(input.getAttribute('formatCharacters')).toNotExist()
+    cleanup(el)
+  })
+
   it('should handle updating multiple values', () => {
     const el = setup()
     let ref = null


### PR DESCRIPTION
Remove `planceHolderChar` and `formatCharacters` from props  before setting them on input element.

The specs had `console.error` stubbed out, which may be why the warnings weren't noticed.  This restores the spy after it's used and adds an explicit spec to test the props are removed.