### PR TITLE
Changelog: fix typo

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,7 @@
 
 * Don’t call `onChange` function if undefined.
 * Update nwb to 0.9.x
-s
+
 ## 3.1.2 / 2016-04-11
 
 * Support for React 15.x.x


### PR DESCRIPTION
just removes a stray char that was breaking the formatting