### PR TITLE
Allow the enter key to trigger an onSubmit callback with the event.

### DIFF
--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -28,6 +28,12 @@ const App = React.createClass({
     }
   },
 
+  _onSubmit(e) {
+    const stateChange = {}
+    stateChange[e.target.name] = e.target.value
+    console.log('submitted', stateChange)
+  },
+
   _onChange(e) {
     const stateChange = {}
     stateChange[e.target.name] = e.target.value
@@ -54,7 +60,7 @@ const App = React.createClass({
       <p className="lead">A React component which creates a masked <code>&lt;input/&gt;</code></p>
       <div className="form-field">
         <label htmlFor="card">Card Number:</label>
-        <MaskedInput mask="1111 1111 1111 1111" name="card" id="card" size="20" value={this.state.card} onChange={this._onChange}/>
+        <MaskedInput onSubmit={this._onSubmit} mask="1111 1111 1111 1111" name="card" id="card" size="20" value={this.state.card} onChange={this._onChange}/>
       </div>
       <p>You can even externally update the card state like a standard input element:</p>
       <div className="form-field">

--- a/src/index.js
+++ b/src/index.js
@@ -59,6 +59,8 @@ function setSelection(el, selection) {
 
 var MaskedInput = React.createClass({
   propTypes: {
+    onChange: React.PropTypes.func,
+    onSubmit: React.PropTypes.func,
     mask: React.PropTypes.string.isRequired,
 
     formatCharacters: React.PropTypes.object,
@@ -200,8 +202,15 @@ var MaskedInput = React.createClass({
     // console.log('onKeyPress', JSON.stringify(getSelection(this.input)), e.key, e.target.value)
 
     // Ignore modified key presses
-    // Ignore enter key to allow form submission
-    if (e.metaKey || e.altKey || e.ctrlKey || e.key === 'Enter') { return }
+    if (e.metaKey || e.altKey || e.ctrlKey) { return }
+
+    // Ignore enter key to allow form submission, but allow explicit onSubmit handler notice
+    if (e.key === 'Enter') {
+      if (this.props.onSubmit) {
+        this.props.onSubmit(e)
+      }
+      return
+    }
 
     e.preventDefault()
     this._updateMaskSelection()


### PR DESCRIPTION
This allows a project I'm working on to use MaskedInput but submit values with the enter key even if not embedded in a proper form. It feels reasonable to use but I haven't tested many scenarios outside what we've envisioned.