### PR TITLE
Use class instead React.createClass 

### DIFF
--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -12,9 +12,11 @@ const PATTERNS = [
   '1 1'
 ]
 
-const App = React.createClass({
-  getInitialState() {
-    return {
+class App extends React.Component {
+  constructor(props) {
+    super(props)
+    
+    this.state = {
       card: '',
       expiry: '',
       ccv: '',
@@ -26,17 +28,17 @@ const App = React.createClass({
       pattern: '1111 1111',
       cardPattern: '1111 1111 1111 1111'
     }
-  },
+  }
 
   _onChange(e) {
     const stateChange = {}
     stateChange[e.target.name] = e.target.value
     this.setState(stateChange)
-  },
+  }
 
   _changePattern(e) {
     this.setState({pattern: e.target.value})
-  },
+  }
 
   _onCardChange(e) {
     if(/^3[47]/.test(e.target.value)) {
@@ -44,7 +46,7 @@ const App = React.createClass({
     } else {
       this.setState({cardPattern: '1111 1111 1111 1111'})
     }
-  },
+  }
 
   render() {
     return <div className="App">
@@ -111,24 +113,21 @@ const App = React.createClass({
       <footer><a href="https://github.com/insin/react-maskedinput">Source on GitHub</a></footer>
     </div>
   }
-})
+}
 
-const CustomInput = React.createClass({
-  render() {
-    return <MaskedInput
-      mask="1111-WW-11"
-      placeholder="1234-WW-12"
-      placeholderChar=" "
-      size="11"
-      {...this.props}
-      formatCharacters={{
-        'W': {
-          validate(char) { return /\w/.test(char) },
-          transform(char) { return char.toUpperCase() }
-        }
+const CustomInput = (props) =>
+  <MaskedInput
+    mask="1111-WW-11"
+    placeholder="1234-WW-12"
+    placeholderChar=" "
+    size="11"
+    {...props}
+    formatCharacters={{
+      'W': {
+        validate(char) { return /\w/.test(char) },
+        transform(char) { return char.toUpperCase() }
       }
-    }/>
-  }
-})
+    }}
+  />
 
 render(<App/>, document.getElementById('demo'))

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "inputmask-core": "^2.1.1"
   },
   "peerDependencies": {
-    "react": "0.14.x || 15.x.x"
+    "react": "0.14.x || 15.x.x",
+    "prop-types": "^15.5.8"
   },
   "devDependencies": {
     "eslint-config-jonnybuchanan": "2.0.3",

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
-var React = require('react')
-var InputMask = require('inputmask-core')
+import React from 'react'
+import PropTypes from 'prop-types'
+import InputMask from 'inputmask-core'
 
 var KEYCODE_Z = 90
 var KEYCODE_Y = 89
@@ -57,20 +58,7 @@ function setSelection(el, selection) {
   catch (e) { /* not focused or not visible */ }
 }
 
-var MaskedInput = React.createClass({
-  propTypes: {
-    mask: React.PropTypes.string.isRequired,
-
-    formatCharacters: React.PropTypes.object,
-    placeholderChar: React.PropTypes.string
-  },
-
-  getDefaultProps() {
-    return {
-      value: ''
-    }
-  },
-
+class MaskedInput extends React.Component {
   componentWillMount() {
     var options = {
       pattern: this.props.mask,
@@ -81,7 +69,7 @@ var MaskedInput = React.createClass({
       options.placeholderChar = this.props.placeholderChar
     }
     this.mask = new InputMask(options)
-  },
+  }
 
   componentWillReceiveProps(nextProps) {
     if (this.props.mask !== nextProps.mask && this.props.value !== nextProps.mask) {
@@ -102,34 +90,34 @@ var MaskedInput = React.createClass({
     else if (this.props.value !== nextProps.value) {
       this.mask.setValue(nextProps.value)
     }
-  },
+  }
 
   componentWillUpdate(nextProps, nextState) {
     if (nextProps.mask !== this.props.mask) {
       this._updatePattern(nextProps)
     }
-  },
+  }
 
   componentDidUpdate(prevProps) {
     if (prevProps.mask !== this.props.mask && this.mask.selection.start) {
       this._updateInputSelection()
     }
-  },
+  }
 
-  _updatePattern: function(props) {
+  _updatePattern(props) {
     this.mask.setPattern(props.mask, {
       value: this.mask.getRawValue(),
       selection: getSelection(this.input)
     })
-  },
+  }
 
   _updateMaskSelection() {
     this.mask.selection = getSelection(this.input)
-  },
+  }
 
   _updateInputSelection() {
     setSelection(this.input, this.mask.selection)
-  },
+  }
 
   _onChange(e) {
     // console.log('onChange', JSON.stringify(getSelection(this.input)), e.target.value)
@@ -152,7 +140,7 @@ var MaskedInput = React.createClass({
     if (this.props.onChange) {
       this.props.onChange(e)
     }
-  },
+  }
 
   _onKeyDown(e) {
     // console.log('onKeyDown', JSON.stringify(getSelection(this.input)), e.key, e.target.value)
@@ -194,7 +182,7 @@ var MaskedInput = React.createClass({
         }
       }
     }
-  },
+  }
 
   _onKeyPress(e) {
     // console.log('onKeyPress', JSON.stringify(getSelection(this.input)), e.key, e.target.value)
@@ -212,7 +200,7 @@ var MaskedInput = React.createClass({
         this.props.onChange(e)
       }
     }
-  },
+  }
 
   _onPaste(e) {
     // console.log('onPaste', JSON.stringify(getSelection(this.input)), e.clipboardData.getData('Text'), e.target.value)
@@ -228,12 +216,12 @@ var MaskedInput = React.createClass({
         this.props.onChange(e)
       }
     }
-  },
+  }
 
   _getDisplayValue() {
     var value = this.mask.getValue()
     return value === this.mask.emptyValue ? '' : value
-  },
+  }
 
   _keyPressPropName() {
     if (typeof navigator !== 'undefined') {
@@ -242,7 +230,7 @@ var MaskedInput = React.createClass({
       : 'onKeyPress'
     }
     return 'onKeyPress'
-  },
+  }
 
   _getEventHandlers() {
     return {
@@ -251,27 +239,38 @@ var MaskedInput = React.createClass({
       onPaste: this._onPaste,
       [this._keyPressPropName()]: this._onKeyPress
     }
-  },
+  }
 
   focus() {
     this.input.focus()
-  },
+  }
 
   blur() {
     this.input.blur()
-  },
+  }
 
   render() {
-    var ref = r => this.input = r
+    var ref = r => { this.input = r }
     var maxLength = this.mask.pattern.length
     var value = this._getDisplayValue()
     var eventHandlers = this._getEventHandlers()
     var { size = maxLength, placeholder = this.mask.emptyValue } = this.props
 
-    var {placeholderChar, formatCharacters, ...cleanedProps} = this.props
+    var { placeholderChar, formatCharacters, ...cleanedProps } = this.props // eslint-disable-line
     var inputProps = { ...cleanedProps, ...eventHandlers, ref, maxLength, value, size, placeholder }
     return <input {...inputProps} />
   }
-})
+}
 
-module.exports = MaskedInput
+MaskedInput.propTypes = {
+  mask: PropTypes.string.isRequired,
+
+  formatCharacters: PropTypes.object,
+  placeholderChar: PropTypes.string
+}
+
+MaskedInput.defaultProps = {
+  value: ''
+}
+
+export default MaskedInput

--- a/src/index.js
+++ b/src/index.js
@@ -59,6 +59,15 @@ function setSelection(el, selection) {
 }
 
 class MaskedInput extends React.Component {
+  constructor(props) {
+    super(props)
+
+    this._onChange = this._onChange.bind(this)
+    this._onKeyDown = this._onKeyDown.bind(this)
+    this._onPaste = this._onPaste.bind(this)
+    this._onKeyPress = this._onKeyPress.bind(this)
+  }
+  
   componentWillMount() {
     var options = {
       pattern: this.props.mask,

--- a/src/index.js
+++ b/src/index.js
@@ -67,7 +67,7 @@ class MaskedInput extends React.Component {
     this._onPaste = this._onPaste.bind(this)
     this._onKeyPress = this._onKeyPress.bind(this)
   }
-  
+
   componentWillMount() {
     var options = {
       pattern: this.props.mask,


### PR DESCRIPTION
Use class instead React.createClass and use prop-types package instead React.PropTypes to prevent deprecation warning fix #70 fix #93