### PR TITLE
Fixed issue with pasting text generates a javascript error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -66,6 +66,7 @@ class MaskedInput extends React.Component {
     this._onKeyDown = this._onKeyDown.bind(this)
     this._onPaste = this._onPaste.bind(this)
     this._onKeyPress = this._onKeyPress.bind(this)
+    this._updateInputSelection = this._updateInputSelection.bind(this)
   }
 
   componentWillMount() {


### PR DESCRIPTION
I hit a bug, where pasting content in masked input, generates a javascript error.

I havent looked to close, but i suspect, when the component was converted to class format (from createClass()), that the binding for the function _updateInputSelection was missed.

Also, not sure if there are other functions that also need binding.

Regards
Dean Netherton
