### PR TITLE
Include React 16 in peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "prop-types": "^15.5.7"
   },
   "peerDependencies": {
-    "react": "^0.14.9 || ^15.3.0"
+    "react": "^0.14.9 || ^15.3.0 || ^16.0.0"
   },
   "devDependencies": {
     "eslint-config-jonnybuchanan": "5.0.x",


### PR DESCRIPTION
This PR only adds React 16 to the list of allowed peer dependency versions. Without this change, users of the package are blocked from upgrading to react 16.

I've intentionally not updated the devDependencies for now, but I've updated them locally to test against the latest version. Everything seems fine; tests run and no problems or deprecation warnings inside an actual application.